### PR TITLE
Do not handle double click on scroll bar as "Open item" event.

### DIFF
--- a/SSLVerifier.WPF/API/MainLogic/Tools.cs
+++ b/SSLVerifier.WPF/API/MainLogic/Tools.cs
@@ -11,7 +11,7 @@ namespace SSLVerifier.API.MainLogic {
             WindowCollection windows = Application.Current.Windows;
             Window hwnd = null;
             if (windows.Count > 0) {
-                hwnd = windows[windows.Count - 1];
+                hwnd = App.Current.MainWindow;
             }
 
             return hwnd == null

--- a/SSLVerifier.WPF/Views/UserControls/MainGridUserControl.xaml.cs
+++ b/SSLVerifier.WPF/Views/UserControls/MainGridUserControl.xaml.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using SSLVerifier.API.ViewModels;
 
 namespace SSLVerifier.Views.UserControls {
@@ -11,7 +15,20 @@ namespace SSLVerifier.Views.UserControls {
 			InitializeComponent();
 		}
 		void lvModulesMouseDoubleClick(Object Sender, MouseButtonEventArgs e) {
-			if (listView.SelectedIndex >= 0 && !((MainWindowVM)DataContext).Running) {
+            DependencyObject dep = (DependencyObject)e.OriginalSource;
+
+            while ((dep != null) && !(dep is TextBlock))
+            {
+                dep = VisualTreeHelper.GetParent(dep);
+            }
+
+            // We have only TextBlock elements in our "GridView"
+            if (dep == null || !(dep is TextBlock))
+            {
+                return;
+            }
+
+            if (listView.SelectedIndex >= 0 && !((MainWindowVM)DataContext).Running) {
 				((MainWindowVM)DataContext).StartSingleScan(null);
 			}
 		}


### PR DESCRIPTION
Когда проявляется проблема: есть список серверов, и если показыватся вертикальная прокрутка, то нажимая на бегунок прокрутки, когда реально "прокручивать" уже дальне некуда, то такое событие ошибочно обрабатывается как двойной click на элемент в списке.

- если бегунок scroll bar-а в конце, то будет открыт последний элемент
- если бегунок scroll bar-а в начале то будет открыт первый элемент
- нажатие на заголовок в "неправильном" месте откроет выбранную запись