### PR TITLE
Correct Save error with XMLSerializer

### DIFF
--- a/SSLVerifier.WPF/API/ModelObjects/ServerObject.cs
+++ b/SSLVerifier.WPF/API/ModelObjects/ServerObject.cs
@@ -39,6 +39,7 @@ namespace SSLVerifier.API.ModelObjects {
                 OnPropertyChanged(nameof(Port));
             }
         }
+        [XmlIgnore]
         public IServerProxy Proxy { get; set; }
         [XmlIgnore]
         public ServerStatusEnum ItemStatus {


### PR DESCRIPTION
Correction for Issue: #7 

 Issue was that an interface the ServerObject.cs needed to be marked XmlIgnore.  Once done, save and load work without issue